### PR TITLE
Update configure-winrm.ps1.j2 for dynamic Network profile name

### DIFF
--- a/roles/ansible_packer/templates/configure-winrm.ps1.j2
+++ b/roles/ansible_packer/templates/configure-winrm.ps1.j2
@@ -1,6 +1,9 @@
 Write-Host Configuring WinRM service...
 
-Set-NetConnectionProfile -Name Network -NetworkCategory Private
+# Retrieve the network profile name
+$networkProfile = Get-NetConnectionProfile | Where-Object { $_.IPv4Connectivity -ne "Disconnected" }
+Set-NetConnectionProfile -InterfaceAlias $networkProfile.InterfaceAlias -NetworkCategory Private
+
 Enable-PSRemoting -Force
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force
 


### PR DESCRIPTION
Hi there, 

I used this role for our RHEL template creation but recently we also wanted to switch our Windows stuff over to it for simplicity. 

While doing so I found it crashing while setting up winrm cause our network profiles where named differently. 

I think the way I changed it should work dynamically for pretty much any infra, but not 100% sure since im very much a Linux eng and not to deep in Windows.

But it did work for us so I guess ok?

In any case feel free to merge or also not however you prefer :)

Thanks for the amazing role!