### PR TITLE
Add missing bracket ending when uploading to content library

### DIFF
--- a/roles/ansible_packer/templates/build-vmware-win.json.j2
+++ b/roles/ansible_packer/templates/build-vmware-win.json.j2
@@ -36,6 +36,7 @@
 {% endif %}
         "ovf": "{{ vcenter_content_library.ovf }}",
         "destroy": "{{ vcenter_content_library.destroy }}"
+        },
 {% endif %}
 
       "vm_name": "{{ vm_name }}",

--- a/roles/ansible_packer/templates/build-vmware.json.j2
+++ b/roles/ansible_packer/templates/build-vmware.json.j2
@@ -35,6 +35,7 @@
 {% endif %}
         "ovf": "{{ vcenter_content_library.ovf }}",
         "destroy": "{{ vcenter_content_library.destroy }}"
+        },
 {% endif %}
 
       "vm_name": "{{ vm_name }}",


### PR DESCRIPTION
We updated our config to auto update the content library but ran into some errors on the build.json with it. 

Seems just a simple bracket that got forgotten. 

